### PR TITLE
为文章api的响应增加发布时间和编辑时间

### DIFF
--- a/api/articles/articles.go
+++ b/api/articles/articles.go
@@ -18,8 +18,10 @@ type Result struct {
 }
 
 type Article struct {
-	Title string `json:"title"`
-	Text  string `json:"text"`
+	Title      string `json:"title"`
+	Text       string `json:"text"`
+	PostedTime string `json:"posted_time"`
+	EditedTime string `json:"edited_time"`
 }
 
 func HandleArticles(w http.ResponseWriter, r *http.Request) {
@@ -27,9 +29,9 @@ func HandleArticles(w http.ResponseWriter, r *http.Request) {
 		StatusCode: http.StatusOK,
 		Result: Result{
 			Articles: []Article{
-				{Title: "怒斥香港记者", Text: "Too young too simple, sometimes naive."},
-				{Title: "与华莱士谈笑风生", Text: "不知道比你们搞到哪里去了"},
-				{Title: "视察国机二院", Text: "苟利国家生死以，岂因祸福避趋之"},
+				{Title: "怒斥香港记者", Text: "Too young too simple, sometimes naive.", PostedTime: "972749166"},
+				{Title: "与华莱士谈笑风生", Text: "不知道比你们搞到哪里去了", PostedTime: "1142348400"},
+				{Title: "视察国机二院", Text: "苟利国家生死以，岂因祸福避趋之", PostedTime: "1240488000"},
 			},
 		},
 		HasMore:    false,


### PR DESCRIPTION
# 课题
文章api的响应里不含有时间信息，但是想在前端显示与文章相关的时间信息。

# 解决方案
在文章api的响应里增添以下的属性
- posted_time (string)
- edit_time (string)

PS. 两者均为timestamp字符串。
