### PR TITLE
文章api响应中的时间类型改成整型

### DIFF
--- a/api/articles/articles.go
+++ b/api/articles/articles.go
@@ -20,8 +20,8 @@ type Result struct {
 type Article struct {
 	Title      string `json:"title"`
 	Text       string `json:"text"`
-	PostedTime string `json:"posted_time"`
-	EditedTime string `json:"edited_time"`
+	PostedTime int    `json:"posted_time"`
+	EditedTime int    `json:"edited_time"`
 }
 
 func HandleArticles(w http.ResponseWriter, r *http.Request) {
@@ -29,9 +29,9 @@ func HandleArticles(w http.ResponseWriter, r *http.Request) {
 		StatusCode: http.StatusOK,
 		Result: Result{
 			Articles: []Article{
-				{Title: "怒斥香港记者", Text: "Too young too simple, sometimes naive.", PostedTime: "972749166"},
-				{Title: "与华莱士谈笑风生", Text: "不知道比你们搞到哪里去了", PostedTime: "1142348400"},
-				{Title: "视察国机二院", Text: "苟利国家生死以，岂因祸福避趋之", PostedTime: "1240488000"},
+				{Title: "怒斥香港记者", Text: "Too young too simple, sometimes naive.", PostedTime: 972749166},
+				{Title: "与华莱士谈笑风生", Text: "不知道比你们搞到哪里去了", PostedTime: 1142348400},
+				{Title: "视察国机二院", Text: "苟利国家生死以，岂因祸福避趋之", PostedTime: 1240488000},
 			},
 		},
 		HasMore:    false,


### PR DESCRIPTION
# 课题
api响应中的timestamp如果为字符串类型的话在js端还要进行类型转换，比较麻烦

# 解决方案
api响应中的timestamp改为int
PS. 以后timestamp都用int