### PR TITLE
修改路由器模式

### DIFF
--- a/app/src/router/index.js
+++ b/app/src/router/index.js
@@ -9,6 +9,7 @@ import Profile from '@/components/Profile'
 Vue.use(Router)
 
 export default new Router({
+  mode: 'history',
   routes: [
     {
       path: '/',


### PR DESCRIPTION
# 课题
vue router默认的路由模式为hash，#略丑

# 解决方案
把vue router的路由模式设置成history
详见https://router.vuejs.org/zh-cn/essentials/history-mode.html