### PR TITLE
Feature/article support rendered as html

### DIFF
--- a/api/articles/articles.go
+++ b/api/articles/articles.go
@@ -23,6 +23,7 @@ type Article struct {
 	CreatedDate string `json:"created_date"`
 	EditedDate  string `json:"edited_date"`
 	CategoryID  int    `json:"category_id"`
+	IsHTML      bool   `json:"is_html"`
 }
 
 func GetArticles(c *elesion.Context) {
@@ -88,11 +89,15 @@ func getArticle(id string) (*Article, error) {
 	defer d.Close()
 
 	article := Article{}
-	err := d.QueryRow("SELECT id, title, text, created_date, edited_date, category_id FROM articles WHERE id = ?", id).Scan(
-		&article.ID, &article.Title, &article.Text, &article.CreatedDate, &article.EditedDate, &article.CategoryID,
+	is_html := false
+	err := d.QueryRow("SELECT id, title, text, created_date, edited_date, category_id, is_html+0 FROM articles WHERE id = ?", id).Scan(
+		&article.ID, &article.Title, &article.Text, &article.CreatedDate, &article.EditedDate, &article.CategoryID, &is_html,
 	)
 	if err != nil {
 		return nil, err
+	}
+	if is_html {
+		article.IsHTML = true
 	}
 	return &article, err
 }

--- a/api/db/queries.go
+++ b/api/db/queries.go
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS articles (
 	title varchar(255) NOT NULL,
 	text text NOT NULL,
 	category_id int,
+	is_html bit DEFAULT 0,
 	PRIMARY KEY (id)
 )
 `

--- a/app/src/components/articles/Article.vue
+++ b/app/src/components/articles/Article.vue
@@ -2,10 +2,11 @@
   <div class="lmm-container lmm-margin" style="margin-left:auto !important; margin-right:auto !important; width:720px">
     <h2 class="lmm-center">{{ title }}</h2>
     <br>
-    <p style="text-align:justify">{{ text }}</p>
+    <div v-if="isHTML" v-html="text" style="text-align:justify"></div>
+    <div v-else style="text-align:justify">{{ text }}</div>
     <br>
-    <p v-if="createdDate === editedDate" class="lmm-right lmm-opacity">Created {{ editedDate }}</p>
-    <p v-else class="lmm-right lmm-opacity">Edited {{ createdDate }}</p>
+    <p v-if="createdDate === editedDate" class="lmm-right lmm-opacity">Created {{ createdDate }}</p>
+    <p v-else class="lmm-right lmm-opacity">Edited {{ editedDate }}</p>
   </div>
 </template>
 
@@ -17,7 +18,8 @@ export default {
       title: '',
       text: '',
       createdDate: '',
-      editedDate: ''
+      editedDate: '',
+      isHTML: 0
     }
   },
   created () {
@@ -28,8 +30,9 @@ export default {
       let article = res.data
       this.title = article.title
       this.text = article.text
-      this.createdDate = article.createdDate
-      this.editedDate = article.editedDate
+      this.createdDate = article.created_date
+      this.editedDate = article.edited_date
+      this.isHTML = article.is_html
     }).catch((e) => {
       console.log(e)
     })


### PR DESCRIPTION
# 课题
想要把文章的内容作为html渲染

# 变更内容
后端：往表`articles`中添加`is_html`列
前端：判断文章是否为`is_html`再进行渲染