### PR TITLE
代码块支持语法高亮

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5605,6 +5605,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "axios": "^0.17.1",
+    "highlight.js": "^9.12.0",
     "js": "^0.1.0",
     "markdown-it": "^8.4.0",
     "vue": "^2.5.2",

--- a/app/src/components/articles/Article.vue
+++ b/app/src/components/articles/Article.vue
@@ -2,7 +2,7 @@
   <div class="lmm-container lmm-margin" style="margin-left:auto !important; margin-right:auto !important; width:720px">
     <h2 class="lmm-center">{{ title }}</h2>
     <br>
-    <div v-html="text" style="text-align:justify"></div>
+    <div v-html="text" v-hljs style="text-align:justify"></div>
     <br>
     <p v-if="createdDate === editedDate" class="lmm-right lmm-opacity">Created {{ editedDate }}</p>
     <p v-else class="lmm-right lmm-opacity">Edited {{ createdDate }}</p>

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -3,8 +3,14 @@
 import Vue from 'vue'
 import App from './App'
 import router from './router'
+import hljs from 'highlight.js'
+import 'highlight.js/styles/github-gist.css'
 
 Vue.config.productionTip = true
+Vue.directive('hljs', el => {
+  let blocks = el.querySelectorAll('pre code')
+  Array.prototype.forEach.call(blocks, hljs.highlightBlock)
+})
 
 /* eslint-disable no-new */
 new Vue({


### PR DESCRIPTION
# 课题
markdown渲染出来的`<pre><code></code></pre>`没有语法高亮

# 解决方案
- 使用highlight.js

# 参考
- Vue使用Highlight.js高亮代码 https://blog.ttionya.com/article-1649.html