### PR TITLE
生成文章副标题

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -20,7 +20,7 @@
     <footer>
       <hr class="lmm-level-opacity">
       <div class="lmm-container lmm-padding-16 lmm-center">
-        <a href="https://github.com/akinaru-lu" target="_blank"><i class="fa fa-github lmm-hover-opacity lmm-xxxlarge lmm-white"></i></a>
+        <a href="https://github.com/akinaru-lu" target="_blank"><i class="fa fa-github lmm-hover lmm-xxxlarge lmm-white"></i></a>
         <p>Powered by <router-link to="/profile" class="mm-light-grey lmm-white lmm-hover-light-grey">Lu Mingming</router-link></p>
       </div>
     </footer>

--- a/app/src/assets/styles/common.css
+++ b/app/src/assets/styles/common.css
@@ -90,7 +90,7 @@
 .lmm-button:hover {
   background-color: #ccc !important;
 }
-.lmm-hover-opacity:hover {
+.lmm-hover:hover {
   opacity: 0.60;
 }
 .lmm-bar .lmm-button {
@@ -113,7 +113,7 @@
   background-color: #f1f1f1 !important;
 }
 .lmm-link {
-  text-decoration:none;
+  text-decoration: none;
 }
 .lmm-left .lmm-margin {
   margin: 16px 8px 16px 8px !important;
@@ -155,6 +155,15 @@
 .lmm-white {
   color: #424949;
   background-color: #fff !important;
+}
+.lmm-white-trans {
+  color: #424949;
+  background-color: #fff !important;
+  -webkit-transition: all 0.5s ease-in-out;
+  -moz-transition: all 0.5s ease-in-out;
+  -o-transition: all 0.5s ease-in-out;
+  -ms-transition: all 0.5s ease-in-out;
+  transition: all 0.5s ease-in-out;
 }
 body {
   font-family: Helvetica, Arial, sans-serif;

--- a/app/src/components/articles/Article.vue
+++ b/app/src/components/articles/Article.vue
@@ -1,11 +1,27 @@
 <template>
-  <div class="lmm-container lmm-margin" style="margin-left:auto !important; margin-right:auto !important; width:720px">
-    <h2 class="lmm-center">{{ title }}</h2>
-    <br>
-    <div v-html="text" v-hljs style="text-align:justify"></div>
-    <br>
-    <p v-if="createdDate === editedDate" class="lmm-right lmm-opacity">Created {{ editedDate }}</p>
-    <p v-else class="lmm-right lmm-opacity">Edited {{ createdDate }}</p>
+  <div class="lmm-row">
+
+    <!-- Article text -->
+    <div class="lmm-left" style="width:75%; display:inline-block">
+      <div class="lmm-container lmm-margin lmm-card-4">
+        <h2 class="lmm-center">{{ title }}</h2>
+        <br>
+        <div v-html="text" v-hljs style="text-align:justify"></div>
+        <br>
+        <p v-if="createdDate === editedDate" class="lmm-right lmm-opacity">Created {{ editedDate }}</p>
+        <p v-else class="lmm-right lmm-opacity">Edited {{ createdDate }}</p>
+      </div>
+    </div>
+
+    <!-- Article chapters navigation -->
+    <div class="lmm-right" style="width:25%; display:inline-block">
+      <div class="lmm-container lmm-margin" style="text-align: left">
+        <p><b>Chapters</b></p>
+        <p v-for="subtitle in subtitles" :key="subtitle.name">
+          <router-link :to="subtitle.link" @click.native="jumpToHash(subtitle.link)" class="lmm-white lmm-link lmm-hover">{{ subtitle.name }}</router-link>
+        </p>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -16,14 +32,14 @@ export default {
   data () {
     return {
       title: '',
+      subtitles: [],
       text: '',
       createdDate: '',
       editedDate: ''
     }
   },
   created () {
-    let pattern = /^\/articles\/(\d)$/g
-    let match = pattern.exec(this.$route.path)
+    let match = /^\/articles\/(\d)$/g.exec(this.$route.path)
     let url = 'http://api.lmm.local' + this.$route.path.replace(/^\/articles\/\d$/, '/article?id=' + match[1])
     let md = new Markdownit({
       html: true,
@@ -35,9 +51,48 @@ export default {
       this.text = md.render(article.text)
       this.createdDate = article.created_date
       this.editedDate = article.edited_date
+
+      // prepare subtitles and their links
+      let results = this.extractSubtitles(this.text, this.$route.path)
+      this.text = results[0]
+      this.subtitles = results[1]
     }).catch((e) => {
       console.log(e)
     })
+  },
+  methods: {
+    jumpToHash: (hash) => {
+      location.href = hash
+
+      // change background color of subtitle for 0.5s
+      let match = /^#(.+)$/g.exec(hash)
+      if (match !== null && match.length >= 2) {
+        let id = match[1]
+        console.log(id)
+        document.getElementById(id).className = 'lmm-light-grey'
+        setTimeout(() => {
+          document.getElementById(id).className = 'lmm-white-trans'
+        }, 500)
+      }
+    },
+    extractSubtitles: (text, url) => {
+      let lines = text.split('\n')
+      let subtitles = []
+
+      // regard all h3 as subtitle
+      lines.forEach((line, index) => {
+        let match = /^<h3>(.+)<\/h3>$/g.exec(line)
+        if (match && match.length >= 2) {
+          let subtitle = {
+            name: match[1],
+            link: '#' + match[1]
+          }
+          subtitles.push(subtitle)
+          lines[index] = '<div id="' + match[1] + '">' + line + '</div>'
+        }
+      })
+      return [lines.join('\n'), subtitles]
+    }
   }
 }
 </script>

--- a/app/src/components/articles/List.vue
+++ b/app/src/components/articles/List.vue
@@ -25,7 +25,7 @@
         <hr>
         <div v-for="category in categories" :key="category.id">
           <p>
-            <router-link to="" class="lmm-white lmm-hover-light-grey" style="text-decoration:none">{{ category.name }}</router-link>
+            <router-link to="" class="lmm-white lmm-link lmm-hover-light-grey">{{ category.name }}</router-link>
           </p>
         </div>
       </div>


### PR DESCRIPTION
# 课题
生成文章副标题并且能够通过链接来跳转

# 变更内容
- 修改一些style class
- 将文章正文中所有的h3视为副标题，并生成跳转到该副标题的链接
- 文章页面的右侧铜鼓列表显示所有副标题，点击其中一个项目则跳转到页面内副标题的相应位置

# 相关issues
[app] 设计文章浏览页面 #77
  