### PR TITLE
[app] 重设计博客浏览界面

### DIFF
--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -81,12 +81,12 @@ export default {
       axios.get('https://api.lmm.im/blogs/' + this.blogID).then(res => {
         const blog = res.data
         this.title = blog.title
-        this.text = md.render(blog.text)
         this.createdAt = blog.created_at
         this.updatedAt = blog.updated_at
 
         // prepare subtitles and their links
-        const results = this.extractSubtitles(this.text, this.$route.path)
+        const text = md.render(blog.text)
+        const results = this.extractSubtitles(text, this.$route.path)
         this.text = results[0]
         this.subtitles = results[1]
       }).catch(e => {
@@ -129,7 +129,6 @@ export default {
       let lines = text.split('\n')
       let subtitles = []
 
-      // regard all h3 as subtitle
       lines.forEach((line, index) => {
         const h = /^<h(\d)>(.+)<\/h(\d)>$/g.exec(line)
         if (!h || h.length !== 4) {

--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -21,10 +21,10 @@
 
     <!-- Blog chapters navigation -->
     <div v-if="!isMobile" class="right nav">
-      <div class="container">
+      <div class="container chapter">
         <h4><i class="fa fa-fw fa-bookmark-o"></i>Chapters</h4>
         <p v-for="subtitle in subtitles" :key="subtitle.name">
-          <router-link :to="subtitle.link" @click.native="jumpToHash(subtitle.link)" class="white link">{{ subtitle.name }}</router-link>
+          <router-link :to="subtitle.link" @click.native="jumpToHash(subtitle.link)" class="white link item">{{ subtitle.name }}</router-link>
         </p>
       </div>
     </div>
@@ -120,15 +120,20 @@ export default {
 
       // regard all h3 as subtitle
       lines.forEach((line, index) => {
-        const match = /^<h3>(.+)<\/h3>$/g.exec(line)
-        if (match && match.length >= 2) {
-          let subtitle = {
-            name: match[1],
-            link: '#' + match[1]
-          }
-          subtitles.push(subtitle)
-          lines[index] = '<div id="' + match[1] + '">' + line + '</div>'
+        const h = /^<h(\d)>(.+)<\/h(\d)>$/g.exec(line)
+        if (!h || h.length !== 4) {
+          return
         }
+        let prefix = ''
+        if (h[1] === h[3]) {
+          prefix = '  '.repeat((Number(h[1]) - 2) * 2)
+        }
+        let subtitle = {
+          name: prefix + h[2],
+          link: '#' + h[2]
+        }
+        subtitles.push(subtitle)
+        lines[index] = '<div id="' + h[2] + '">' + line + '</div>'
       })
       return [lines.join('\n'), subtitles]
     },
@@ -148,5 +153,8 @@ export default {
 }
 .mobile-left {
   width: 100% !important;
+}
+.chapter .item{
+  white-space: pre;
 }
 </style>

--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -4,7 +4,7 @@
     <div class="left" :class="{ 'mobile-left': isMobile }">
       <div class="container">
         <h1 class="center">{{ title }}</h1>
-        <div v-html="text" v-hljs class="text"></div>
+        <div ref="text" v-html="text" v-hljs class="text"></div>
         <p v-if="createdAt === updatedAt" class="text-right opacity">Created at {{ createdAt }}</p>
         <p v-else class="text-right opacity">Updated at {{ updatedAt }}</p>
       </div>
@@ -23,6 +23,7 @@
     <div v-if="!isMobile" class="right nav">
       <div class="container chapter">
         <h4><i class="fa fa-fw fa-bookmark-o"></i>Chapters</h4>
+        <div class="progress-bar" :style="{ width: progress + '%' }"/>
         <p v-for="subtitle in subtitles" :key="subtitle.name">
           <router-link :to="subtitle.link" @click.native="jumpToHash(subtitle.link)" class="white link item">{{ subtitle.name }}</router-link>
         </p>
@@ -44,7 +45,8 @@ export default {
       createdAt: '',
       updatedAt: '',
       category: null,
-      tags: []
+      tags: [],
+      progress: 0
     }
   },
   created () {
@@ -57,9 +59,18 @@ export default {
     this.fetchTags()
     this.calcIsMobile()
     window.addEventListener('resize', this.calcIsMobile)
+    window.addEventListener('scroll', this.calcProgress)
+  },
+  watch: {
+    text: function () {
+      this.$nextTick(() => {
+        this.calcProgress()
+      })
+    }
   },
   beforeDestroy () {
     window.removeEventListener('resize', this.calcIsMobile)
+    window.removeEventListener('scroll', this.calcProgress)
   },
   methods: {
     fetchBlog: function () {
@@ -137,6 +148,11 @@ export default {
       })
       return [lines.join('\n'), subtitles]
     },
+    calcProgress () {
+      let el = this.$refs.text
+      let progress = ((window.scrollY + window.innerHeight) - el.offsetTop) / (el.offsetHeight)
+      this.progress = progress > 1 ? 100 : progress * 100
+    },
     calcIsMobile () {
       this.isMobile = window.innerWidth <= 768
     }
@@ -156,5 +172,9 @@ export default {
 }
 .chapter .item{
   white-space: pre;
+}
+.progress-bar {
+  border-top: 1px solid red;
+  width: 0;
 }
 </style>

--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -3,7 +3,7 @@
     <!-- Blog text -->
     <div class="left" :class="{ 'mobile-left': isMobile }">
       <div class="container">
-        <h2 class="center">{{ title }}</h2>
+        <h1 class="center">{{ title }}</h1>
         <div v-html="text" v-hljs class="text"></div>
         <p v-if="createdAt === updatedAt" class="text-right opacity">Created at {{ createdAt }}</p>
         <p v-else class="text-right opacity">Updated at {{ updatedAt }}</p>


### PR DESCRIPTION
# 变更内容
- 标题部分
  - 改成h1
- 副标题快捷定位列表部分
  - h2以下的标题都抽取为副标题，并根据h*中*代表的数字进行缩进(indent = (x - 2) * 2)
- 显示浏览进度条
  - 把浏览器窗口最下端视为最新进度
  - 进度条为红色

# 相关issue
[app] 副标题重构 #117