### PR TITLE
Feature/api blog reduce api response information

### DIFF
--- a/api/controller/blog/blog.go
+++ b/api/controller/blog/blog.go
@@ -64,6 +64,21 @@ func GetByUser(c *elesion.Context) {
 	c.Status(http.StatusOK).JSON(blogs)
 }
 
+func GetList(c *elesion.Context) {
+	userID, err := strconv.ParseInt(c.Params.ByName("user"), 10, 64)
+	if err != nil {
+		c.Status(http.StatusBadRequest).String("Invalid user ID").Error(err.Error())
+		return
+	}
+
+	blogs, err := usecase.FetchListByUser(userID)
+	if err != nil {
+		c.Status(http.StatusNotFound).String("Blogs not found").Error(err.Error())
+		return
+	}
+	c.Status(http.StatusOK).JSON(blogs)
+}
+
 func Update(c *elesion.Context) {
 	// check token
 	usr, err := user.Verify(c.Request.Header.Get("Authorization"))

--- a/api/domain/model/blog/blog.go
+++ b/api/domain/model/blog/blog.go
@@ -5,6 +5,12 @@ type Minimal struct {
 	Text  string `json:"text"`
 }
 
+type ListItem struct {
+	ID        int64  `json:"id"`
+	Title     string `json:"title"`
+	CreatedAt string `json:"created_at"`
+}
+
 type Blog struct {
 	ID        int64  `json:"id"`
 	User      int64  `json:"user"`

--- a/api/domain/repository/blog/blog.go
+++ b/api/domain/repository/blog/blog.go
@@ -63,6 +63,31 @@ func ByUser(userID int64) ([]model.Blog, error) {
 	return blogs, nil
 }
 
+func List(userID int64) ([]model.ListItem, error) {
+	d := db.Default()
+	defer d.Close()
+
+	stmt := d.Must("SELECT id, title, created_at FROM blog WHERE user = ? ORDER BY created_at DESC")
+	defer stmt.Close()
+
+	itr, err := stmt.Query(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	blogs := make([]model.ListItem, 0)
+	for itr.Next() {
+		blog := model.ListItem{}
+		err = itr.Scan(&blog.ID, &blog.Title, &blog.CreatedAt)
+		if err != nil {
+			return blogs, err
+		}
+		blogs = append(blogs, blog)
+	}
+
+	return blogs, nil
+}
+
 func Update(id int64, title, text string) error {
 	d := db.Default()
 	defer d.Close()

--- a/api/main.go
+++ b/api/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	// blog
 	router.GET("/blogs/:blog", blog.Get)
-	router.GET("/users/:user/blogs", blog.GetByUser)
+	router.GET("/users/:user/blogs", blog.GetList)
 	router.POST("/blogs", blog.Post)
 	router.PUT("/blogs/:blog", blog.Update)
 	router.DELETE("/blogs/:blog", blog.Delete)

--- a/api/usecase/blog/blog.go
+++ b/api/usecase/blog/blog.go
@@ -20,6 +20,10 @@ func FetchByUser(userID int64) ([]model.Blog, error) {
 	return repo.ByUser(userID)
 }
 
+func FetchListByUser(userID int64) ([]model.ListItem, error) {
+	return repo.List(userID)
+}
+
 func Update(id int64, title, text string) error {
 	title = strings.TrimSpace(title)
 	text = strings.TrimSpace(text)


### PR DESCRIPTION
# 课题
减少`/users/:user/blogs`的响应的信息量，加快客户端反应

# 变更内容
`/users/:user/blogs`只返回以下key
- id
- title
- created_at
主要删去了博客文本text，因为含的字节数较大，对客户端来说是冗余信息