### PR TITLE
fix regexp

### DIFF
--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -50,7 +50,7 @@ export default {
     }
   },
   created () {
-    const pattern = /^v\d\/\/blog\/(\d+)$/g
+    const pattern = /^\/blog\/(\d+)$/g
     const match = pattern.exec(this.$route.path)
     const id = match[1]
     this.blogID = id

--- a/manager/src/components/blog/Edit.vue
+++ b/manager/src/components/blog/Edit.vue
@@ -25,7 +25,7 @@ export default {
     }
   },
   created () {
-    const pattern = /^v\d\/\/blog\/(\d+)\/edit$/g
+    const pattern = /^\/blog\/(\d+)\/edit$/g
     const match = pattern.exec(this.$route.path)
     this.blogID = match[1]
     this.fetchData()


### PR DESCRIPTION
# 课题
在versioning api(#222)之后，由于前端要使用带版本号的api，在修正endpoint的时候不小心把判断当前页面的博客ID用的正则表达式也加上了版本号，实际上app的url里不带版本号，只有api的url带版本号