### PR TITLE
Feature/app styling blockquote and fix

### DIFF
--- a/app/src/assets/styles/blog.css
+++ b/app/src/assets/styles/blog.css
@@ -12,7 +12,7 @@
     margin-right: auto;
     margin-left: 0;
     max-width: 192px;
-    border: 1px solid #e1e1e1;
+    border: 1px solid #eee;
 }
 .container .tag {
     margin-bottom: 16px;

--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -200,4 +200,10 @@ export default {
 .left >>> img {
   width: 100%;
 }
+.left >>> blockquote {
+  background: #f9f9f9;
+  border-left: 8px solid #ccc;
+  margin: 1.5em 0;
+  padding: 0.5em 16px;
+}
 </style>

--- a/app/src/components/blog/Blog.vue
+++ b/app/src/components/blog/Blog.vue
@@ -167,14 +167,16 @@ export default {
 .left >>> h1 {
   text-align: center;
 }
-.left >>> h2:before {
+.left >>> h3:before {
   white-space: pre-wrap;
   border-left: 5px solid #11AF33;
+  opacity: 0.6;
   content: '  ';
 }
 .left >>> h2 {
   font-weight: 400;
   color: #11AF33;
+  border-bottom: 1px solid #eee;
 }
 .left >>> h3 {
   font-weight: 400;


### PR DESCRIPTION
# 变更内容
更改stylesheet
- heading
    - h2
<img width="164" alt="screen shot 2018-03-03 at 4 09 08" src="https://user-images.githubusercontent.com/17140497/36916797-46d1c6ee-1e98-11e8-8bd7-2299d74da0c5.png">
    - h3
<img width="217" alt="screen shot 2018-03-03 at 4 09 15" src="https://user-images.githubusercontent.com/17140497/36916806-4e357ca0-1e98-11e8-8c43-267948b2d6d1.png">

- blockquote
<img width="799" alt="screen shot 2018-03-03 at 4 10 01" src="https://user-images.githubusercontent.com/17140497/36916827-5f17b97a-1e98-11e8-8e58-4bc273069e0e.png">


# 相关issue
styling blockquotes #238