### PR TITLE
fix: should create a repository interface implementation from infra

### DIFF
--- a/api/context/blog/appservice/appservice_test.go
+++ b/api/context/blog/appservice/appservice_test.go
@@ -3,7 +3,7 @@ package appservice
 import (
 	accountFactory "lmm/api/context/account/domain/factory"
 	account "lmm/api/context/account/domain/model"
-	accountRepository "lmm/api/context/account/domain/repository"
+	accountStorage "lmm/api/context/account/infra"
 	"lmm/api/context/blog/infra"
 	"lmm/api/testing"
 	"lmm/api/utils/uuid"
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 	// init user
 	name, password := uuid.New()[:31], uuid.New()
 	user, _ = accountFactory.NewUser(name, password)
-	accountRepository.New(testing.DB()).Add(user)
+	accountStorage.NewUserStorage(testing.DB()).Add(user)
 
 	code := m.Run()
 	os.Exit(code)

--- a/api/context/blog/appservice/blog_test.go
+++ b/api/context/blog/appservice/blog_test.go
@@ -3,7 +3,7 @@ package appservice
 import (
 	"fmt"
 	accountFactory "lmm/api/context/account/domain/factory"
-	accountRepository "lmm/api/context/account/domain/repository"
+	accountStorage "lmm/api/context/account/infra"
 	"lmm/api/context/blog/domain/factory"
 	"lmm/api/context/blog/domain/service"
 	"lmm/api/context/blog/infra"
@@ -147,7 +147,7 @@ func TestEditBlog_NoPermission(tt *testing.T) {
 	repo.Add(blog)
 
 	suspicious, _ := accountFactory.NewUser(uuid.New()[:31], uuid.New())
-	accountRepository.New(testing.DB()).Add(suspicious)
+	accountStorage.NewUserStorage(testing.DB()).Add(suspicious)
 
 	blogContent := BlogContent{
 		Title: uuid.New(),

--- a/api/context/blog/domain/service/service_test.go
+++ b/api/context/blog/domain/service/service_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	accountFactory "lmm/api/context/account/domain/factory"
 	account "lmm/api/context/account/domain/model"
-	accountRepository "lmm/api/context/account/domain/repository"
+	"lmm/api/context/account/infra"
 	"lmm/api/testing"
 	"lmm/api/utils/uuid"
 	"os"
@@ -14,7 +14,7 @@ var user *account.User
 func TestMain(m *testing.M) {
 	name, password := uuid.New()[:31], uuid.New()
 	user, _ = accountFactory.NewUser(name, password)
-	accountRepository.New(testing.DB()).Add(user)
+	infra.NewUserStorage(testing.DB()).Add(user)
 
 	code := m.Run()
 	os.Exit(code)

--- a/api/context/blog/ui/put_blog_test.go
+++ b/api/context/blog/ui/put_blog_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 	accountFactory "lmm/api/context/account/domain/factory"
-	accountRepository "lmm/api/context/account/domain/repository"
 	accountService "lmm/api/context/account/domain/service"
+	accountStorage "lmm/api/context/account/infra"
 	"lmm/api/context/blog/appservice"
 	"lmm/api/context/blog/domain/factory"
 	"lmm/api/context/blog/domain/service"
@@ -144,7 +144,7 @@ func TestUpdateBlog_NoPermission(tt *testing.T) {
 
 	otherUser, err := accountFactory.NewUser(uuid.New()[:31], uuid.New())
 	t.NoError(err)
-	accountRepo := accountRepository.New(testing.DB())
+	accountRepo := accountStorage.NewUserStorage(testing.DB())
 	t.NoError(accountRepo.Add(otherUser))
 
 	headers := make(map[string]string)

--- a/api/context/blog/ui/ui_test.go
+++ b/api/context/blog/ui/ui_test.go
@@ -3,8 +3,8 @@ package ui
 import (
 	accountFactory "lmm/api/context/account/domain/factory"
 	accountModel "lmm/api/context/account/domain/model"
-	accountRepository "lmm/api/context/account/domain/repository"
 	accountService "lmm/api/context/account/domain/service"
+	accountStorage "lmm/api/context/account/infra"
 	account "lmm/api/context/account/ui"
 	"lmm/api/context/blog/infra"
 	"lmm/api/testing"
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	initUser()
 	initUI()
 
-	accountUI = account.New(testing.DB())
+	accountUI = account.New(accountStorage.NewUserStorage(testing.DB()))
 
 	code := m.Run()
 	os.Exit(code)
@@ -35,7 +35,7 @@ func initUser() {
 		panic(err)
 	}
 
-	err = accountRepository.New(testing.DB()).Add(user)
+	err = accountStorage.NewUserStorage(testing.DB()).Add(user)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
后端重构 #344

repository成为了interface，由infra层去进行具体实现