### PR TITLE
Refactor/api pass error object to checking duplicate error

### DIFF
--- a/api/context/account/domain/service/user.go
+++ b/api/context/account/domain/service/user.go
@@ -39,7 +39,7 @@ func (s *UserService) Register(name, password string) (*model.User, error) {
 		return user, nil
 	}
 
-	if key, _, ok := storage.CheckErrorDuplicate(err.Error()); ok {
+	if key, _, ok := storage.CheckErrorDuplicate(err); ok {
 		if key == "name" {
 			return nil, ErrDuplicateUserName
 		}

--- a/api/context/blog/domain/service/blog.go
+++ b/api/context/blog/domain/service/blog.go
@@ -25,7 +25,7 @@ func (s *BlogService) PostBlog(userID uint64, title, text string) (*model.Blog, 
 		return nil, err
 	}
 	if err := s.repo.Add(blog); err != nil {
-		key, _, ok := storage.CheckErrorDuplicate(err.Error())
+		key, _, ok := storage.CheckErrorDuplicate(err)
 		if !ok {
 			return nil, err
 		}

--- a/api/context/blog/domain/service/category.go
+++ b/api/context/blog/domain/service/category.go
@@ -25,7 +25,7 @@ func (s *CategoryService) RegisterCategory(name string) (*model.Category, error)
 	if err == nil {
 		return category, nil
 	}
-	key, _, ok := storage.CheckErrorDuplicate(err.Error())
+	key, _, ok := storage.CheckErrorDuplicate(err)
 	if ok {
 		if key == "name" {
 			return nil, ErrDuplicateCategoryName

--- a/api/context/blog/infra/tag_test.go
+++ b/api/context/blog/infra/tag_test.go
@@ -47,7 +47,7 @@ func TestAddTag_DuplicateBlogTag(tt *testing.T) {
 	t.NoError(err)
 
 	err = repo.Add(tag)
-	key, entry, ok := storage.CheckErrorDuplicate(err.Error())
+	key, entry, ok := storage.CheckErrorDuplicate(err)
 	t.True(ok)
 	t.Is(fmt.Sprintf("%d-%s", tag.BlogID(), tag.Name()), entry)
 	t.Is("blog_tag", key)

--- a/api/storage/db.go
+++ b/api/storage/db.go
@@ -70,8 +70,11 @@ func (db *DB) MustPreparef(format string, args ...interface{}) *sql.Stmt {
 	return db.MustPrepare(query)
 }
 
-func CheckErrorDuplicate(errMsg string) (key string, entry string, ok bool) {
-	matched := ErrPatternDuplicate.FindStringSubmatch(errMsg)
+func CheckErrorDuplicate(err error) (key string, entry string, ok bool) {
+	if err == nil {
+		return "", "", false
+	}
+	matched := ErrPatternDuplicate.FindStringSubmatch(err.Error())
 	if len(matched) == 3 {
 		key = matched[2]
 		entry = matched[1]


### PR DESCRIPTION
往函数传递`err.Error()`的时候，err可能为空，为避免往该函数传递参数前检查err，此p-r修改为直接往该函数传递err本身，在函数里进行nil判断