### PR TITLE
Refactor/api blog define reuseable variables under domain package

### DIFF
--- a/api/context/blog/appservice/blog.go
+++ b/api/context/blog/appservice/blog.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	account "lmm/api/context/account/domain/model"
-	"lmm/api/context/blog/domain/service"
+	"lmm/api/context/blog/domain"
 	"lmm/api/utils/strings"
 )
 
@@ -28,7 +28,7 @@ func (app *AppService) GetBlogListByPage(countStr, pageStr string) (*BlogListPag
 	}
 	count, err := strings.StrToInt(countStr)
 	if err != nil {
-		return nil, service.ErrInvalidCount
+		return nil, domain.ErrInvalidCount
 	}
 
 	if pageStr == "" {
@@ -36,7 +36,7 @@ func (app *AppService) GetBlogListByPage(countStr, pageStr string) (*BlogListPag
 	}
 	page, err := strings.StrToInt(pageStr)
 	if err != nil {
-		return nil, service.ErrInvalidPage
+		return nil, domain.ErrInvalidPage
 	}
 
 	blogList, nextPage, err := app.blogService.GetBlogListByPage(count, page)
@@ -68,7 +68,7 @@ func (app *AppService) GetBlogListByPage(countStr, pageStr string) (*BlogListPag
 func (app *AppService) GetBlogByID(blogIDStr string) (*Blog, error) {
 	blogID, err := strings.StrToUint64(blogIDStr)
 	if err != nil {
-		return nil, service.ErrInvalidBlogID
+		return nil, domain.ErrInvalidBlogID
 	}
 	blog, err := app.blogService.GetBlogByID(blogID)
 	if err != nil {
@@ -88,7 +88,7 @@ func (app *AppService) GetBlogByID(blogIDStr string) (*Blog, error) {
 func (app *AppService) EditBlog(user *account.User, blogIDStr string, requestBody io.ReadCloser) error {
 	blogID, err := strings.StrToUint64(blogIDStr)
 	if err != nil {
-		return service.ErrNoSuchBlog
+		return domain.ErrNoSuchBlog
 	}
 
 	content := BlogContent{}

--- a/api/context/blog/appservice/blog_test.go
+++ b/api/context/blog/appservice/blog_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	accountFactory "lmm/api/context/account/domain/factory"
 	accountStorage "lmm/api/context/account/infra"
+	"lmm/api/context/blog/domain"
 	"lmm/api/context/blog/domain/factory"
-	"lmm/api/context/blog/domain/service"
 	"lmm/api/context/blog/infra"
 	"lmm/api/testing"
 	"lmm/api/utils/uuid"
@@ -100,7 +100,7 @@ func TestFindBlogByID_InvalidID(tt *testing.T) {
 	t := testing.NewTester(tt)
 
 	blog, err := app.GetBlogByID("NAN")
-	t.Is(service.ErrInvalidBlogID, err)
+	t.Is(domain.ErrInvalidBlogID, err)
 	t.Nil(blog)
 }
 
@@ -108,7 +108,7 @@ func TestFindBlogByID_NotFound(tt *testing.T) {
 	t := testing.NewTester(tt)
 
 	blog, err := app.GetBlogByID("112233")
-	t.Is(service.ErrNoSuchBlog, err)
+	t.Is(domain.ErrNoSuchBlog, err)
 	t.Nil(blog)
 }
 
@@ -155,7 +155,7 @@ func TestEditBlog_NoPermission(tt *testing.T) {
 	}
 
 	t.Is(
-		service.ErrNoPermission,
+		domain.ErrNoPermission,
 		app.EditBlog(suspicious, fmt.Sprintf("%d", blog.ID()), testing.StructToRequestBody(blogContent)),
 	)
 }
@@ -173,7 +173,7 @@ func TestEditBlog_NoSuchBlog(tt *testing.T) {
 
 	// notice that I didn' save that blog and here I reverse the title and the text to exclude ErrBlogNoChange
 	t.Is(
-		service.ErrNoSuchBlog,
+		domain.ErrNoSuchBlog,
 		app.EditBlog(user, fmt.Sprintf("%d", blog.ID()), testing.StructToRequestBody(blogContent)),
 	)
 }
@@ -192,7 +192,7 @@ func TestEditBlog_NoChange(tt *testing.T) {
 	}
 
 	t.Is(
-		service.ErrBlogNoChange,
+		domain.ErrBlogNoChange,
 		app.EditBlog(user, fmt.Sprintf("%d", blog.ID()), testing.StructToRequestBody(blogContent)),
 	)
 }
@@ -211,7 +211,7 @@ func TestEditBlog_EmptyTitle(tt *testing.T) {
 	}
 
 	t.Is(
-		service.ErrEmptyBlogTitle,
+		domain.ErrEmptyBlogTitle,
 		app.EditBlog(user, fmt.Sprintf("%d", blog.ID()), testing.StructToRequestBody(blogContent)),
 	)
 }

--- a/api/context/blog/appservice/category.go
+++ b/api/context/blog/appservice/category.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	account "lmm/api/context/account/domain/model"
-	"lmm/api/context/blog/domain/service"
+	"lmm/api/context/blog/domain"
 	"lmm/api/utils/strings"
 )
 
@@ -25,7 +25,7 @@ func (app *AppService) RegisterNewCategory(user *account.User, requestBody io.Re
 func (app *AppService) EditCategory(user *account.User, categoryIDStr string, requestBody io.ReadCloser) error {
 	categoryID, err := strings.StrToUint64(categoryIDStr)
 	if err != nil {
-		return service.ErrInvalidCategoryID
+		return domain.ErrInvalidCategoryID
 	}
 
 	category := Category{}
@@ -103,7 +103,7 @@ func (app *AppService) SetBlogCategory(blogIDStr string, requestBody io.ReadClos
 func (app *AppService) RemoveCategoryByID(idStr string) error {
 	id, err := strings.StrToUint64(idStr)
 	if err != nil {
-		return service.ErrInvalidCategoryID
+		return domain.ErrInvalidCategoryID
 	}
 	return app.categoryService.RemoveCategoryByID(id)
 }

--- a/api/context/blog/appservice/category_test.go
+++ b/api/context/blog/appservice/category_test.go
@@ -2,8 +2,8 @@ package appservice
 
 import (
 	"fmt"
+	"lmm/api/context/blog/domain"
 	"lmm/api/context/blog/domain/model"
-	"lmm/api/context/blog/domain/service"
 	"lmm/api/context/blog/infra"
 	"lmm/api/domain/factory"
 	"lmm/api/testing"
@@ -35,7 +35,7 @@ func TestAddNewCategory_EmptyName(tt *testing.T) {
 	}
 
 	id, err := app.RegisterNewCategory(user, testing.StructToRequestBody(body))
-	t.Is(service.ErrInvalidCategoryName, err)
+	t.Is(domain.ErrInvalidCategoryName, err)
 	t.Is(uint64(0), id)
 }
 
@@ -50,7 +50,7 @@ func TestAddNewCategory_DuplicatedName(tt *testing.T) {
 	t.NoError(err)
 
 	_, err = app.RegisterNewCategory(user, testing.StructToRequestBody(body))
-	t.Is(service.ErrDuplicateCategoryName, err)
+	t.Is(domain.ErrDuplicateCategoryName, err)
 }
 
 func TestUpdateCategoryName_Success(tt *testing.T) {
@@ -85,7 +85,7 @@ func TestUpdateCategoryName_InvalidID(tt *testing.T) {
 	}
 
 	t.Is(
-		service.ErrInvalidCategoryID,
+		domain.ErrInvalidCategoryID,
 		app.EditCategory(user, "invalid id???", testing.StructToRequestBody(body)),
 	)
 }
@@ -101,7 +101,7 @@ func TestUpdateCategoryName_NoSuchCategory(tt *testing.T) {
 
 	err := app.EditCategory(user, fmt.Sprint(id), testing.StructToRequestBody(body))
 
-	t.Is(service.ErrNoSuchCategory, err)
+	t.Is(domain.ErrNoSuchCategory, err)
 }
 
 func TestUpdateCategoryName_InvalidCategoryName(tt *testing.T) {
@@ -119,7 +119,7 @@ func TestUpdateCategoryName_InvalidCategoryName(tt *testing.T) {
 	}
 
 	t.Is(
-		service.ErrInvalidCategoryName,
+		domain.ErrInvalidCategoryName,
 		app.EditCategory(user, fmt.Sprint(id), testing.StructToRequestBody(body)),
 	)
 }
@@ -135,7 +135,7 @@ func TestUpdateCategoryName_CategoryNameNoChanged(tt *testing.T) {
 	t.NoError(err)
 
 	t.Is(
-		service.ErrCategoryNoChanged,
+		domain.ErrCategoryNoChanged,
 		app.EditCategory(user, fmt.Sprint(id), testing.StructToRequestBody(body)),
 	)
 }
@@ -159,7 +159,7 @@ func TestRemoveCategory_Success(tt *testing.T) {
 func TestRemoveCategory_InvalidID(tt *testing.T) {
 	t := testing.NewTester(tt)
 
-	t.Is(service.ErrInvalidCategoryID, app.RemoveCategoryByID("invalid id !?"))
+	t.Is(domain.ErrInvalidCategoryID, app.RemoveCategoryByID("invalid id !?"))
 }
 
 func TestRemoveCategory_NoSuchCategory(tt *testing.T) {
@@ -167,5 +167,5 @@ func TestRemoveCategory_NoSuchCategory(tt *testing.T) {
 
 	id, _ := factory.Default().GenerateID()
 	err := app.RemoveCategoryByID(fmt.Sprint(id))
-	t.Is(service.ErrNoSuchCategory, err)
+	t.Is(domain.ErrNoSuchCategory, err)
 }

--- a/api/context/blog/domain/service/blog.go
+++ b/api/context/blog/domain/service/blog.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"lmm/api/context/blog/domain"
 	"lmm/api/context/blog/domain/factory"
 	"lmm/api/context/blog/domain/model"
 	"lmm/api/context/blog/domain/repository"
@@ -17,7 +18,7 @@ func NewBlogService(repo repository.BlogRepository) *BlogService {
 
 func (s *BlogService) PostBlog(userID uint64, title, text string) (*model.Blog, error) {
 	if title == "" {
-		return nil, ErrEmptyBlogTitle
+		return nil, domain.ErrEmptyBlogTitle
 	}
 
 	blog, err := factory.NewBlog(userID, title, text)
@@ -30,7 +31,7 @@ func (s *BlogService) PostBlog(userID uint64, title, text string) (*model.Blog, 
 			return nil, err
 		}
 		if key == "title" {
-			return nil, ErrBlogTitleDuplicated
+			return nil, domain.ErrBlogTitleDuplicated
 		}
 		return nil, err
 	}
@@ -47,7 +48,7 @@ func (s *BlogService) GetBlogByID(id uint64) (*model.Blog, error) {
 	case nil:
 		return blog, nil
 	case storage.ErrNoRows:
-		return nil, ErrNoSuchBlog
+		return nil, domain.ErrNoSuchBlog
 	default:
 		return nil, err
 	}
@@ -56,30 +57,30 @@ func (s *BlogService) GetBlogByID(id uint64) (*model.Blog, error) {
 func (s *BlogService) EditBlog(userID, blogID uint64, title, text string) error {
 	blog, err := s.repo.FindByID(blogID)
 	if err != nil {
-		return ErrNoSuchBlog
+		return domain.ErrNoSuchBlog
 	}
 
 	if blog.UserID() != userID {
-		return ErrNoPermission
+		return domain.ErrNoPermission
 	}
 
 	lastUpdated := blog.UpdatedAt()
 
 	// TODO move validation to model
 	if title == "" {
-		return ErrEmptyBlogTitle
+		return domain.ErrEmptyBlogTitle
 	}
 
 	blog.UpdateTitle(title)
 	blog.UpdateText(text)
 
 	if blog.UpdatedAt().Equal(lastUpdated) {
-		return ErrBlogNoChange
+		return domain.ErrBlogNoChange
 	}
 
 	err = s.repo.Update(blog)
 	if err == storage.ErrNoChange {
-		return ErrNoSuchBlog
+		return domain.ErrNoSuchBlog
 	}
 
 	return err

--- a/api/context/blog/domain/service/blog_test.go
+++ b/api/context/blog/domain/service/blog_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"lmm/api/context/blog/domain"
 	"lmm/api/context/blog/domain/model"
 	"lmm/api/context/blog/infra"
 	"lmm/api/testing"
@@ -44,7 +45,7 @@ func TestPostBlog_DuplicateTitle(tt *testing.T) {
 	t.Isa(&model.Blog{}, blog)
 
 	blog, err = service.PostBlog(user.ID(), title, text)
-	t.Is(ErrBlogTitleDuplicated, err)
+	t.Is(domain.ErrBlogTitleDuplicated, err)
 	t.Nil(blog)
 }
 
@@ -54,7 +55,7 @@ func TestPostBlog_EmptyTitle(tt *testing.T) {
 	service := NewBlogService(repo)
 
 	blog, err := service.PostBlog(user.ID(), "", uuid.New())
-	t.Is(ErrEmptyBlogTitle, err)
+	t.Is(domain.ErrEmptyBlogTitle, err)
 	t.Nil(blog)
 }
 

--- a/api/context/blog/domain/service/category.go
+++ b/api/context/blog/domain/service/category.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"lmm/api/context/blog/domain"
 	"lmm/api/context/blog/domain/factory"
 	"lmm/api/context/blog/domain/model"
 	"lmm/api/context/blog/domain/repository"
@@ -28,7 +29,7 @@ func (s *CategoryService) RegisterCategory(name string) (*model.Category, error)
 	key, _, ok := storage.CheckErrorDuplicate(err)
 	if ok {
 		if key == "name" {
-			return nil, ErrDuplicateCategoryName
+			return nil, domain.ErrDuplicateCategoryName
 		}
 	}
 	return nil, err
@@ -44,7 +45,7 @@ func (s *CategoryService) GetCategoryByID(id uint64) (*model.Category, error) {
 	case nil:
 		return category, nil
 	case storage.ErrNoRows:
-		return nil, ErrNoSuchCategory
+		return nil, domain.ErrNoSuchCategory
 	default:
 		return nil, err
 	}
@@ -56,7 +57,7 @@ func (s *CategoryService) GetCategoryByName(name string) (*model.Category, error
 	case nil:
 		return category, nil
 	case storage.ErrNoRows:
-		return nil, ErrNoSuchCategory
+		return nil, domain.ErrNoSuchCategory
 	default:
 		return nil, err
 	}
@@ -68,7 +69,7 @@ func (s *CategoryService) GetCategoryOf(blog *model.Blog) (*model.Category, erro
 	case nil:
 		return category, nil
 	case storage.ErrNoRows:
-		return nil, ErrCategoryNotSet
+		return nil, domain.ErrCategoryNotSet
 	default:
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (s *CategoryService) UpdateCategory(category *model.Category) error {
 	case nil:
 		return nil
 	case storage.ErrNoChange:
-		return ErrCategoryNoChanged
+		return domain.ErrCategoryNoChanged
 	default:
 		return err
 	}
@@ -89,7 +90,7 @@ func (s *CategoryService) UpdateCategory(category *model.Category) error {
 func (s *CategoryService) RemoveCategoryByID(id uint64) error {
 	category, err := s.repo.FindByID(id)
 	if err != nil {
-		return ErrNoSuchCategory
+		return domain.ErrNoSuchCategory
 	}
 
 	return s.repo.Remove(category)

--- a/api/context/blog/domain/variables.go
+++ b/api/context/blog/domain/variables.go
@@ -1,4 +1,4 @@
-package service
+package domain
 
 import "errors"
 
@@ -22,4 +22,9 @@ var (
 	ErrInvalidCategoryID     = errors.New("invalid category id")
 	ErrInvalidCategoryName   = errors.New("invalid category name")
 	ErrNoSuchCategory        = errors.New("no such category")
+)
+
+// tag
+var (
+	ErrDuplicateTagName = errors.New("duplicate tag name")
 )

--- a/api/context/blog/ui/ui.go
+++ b/api/context/blog/ui/ui.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	account "lmm/api/context/account/domain/model"
 	"lmm/api/context/blog/appservice"
+	"lmm/api/context/blog/domain"
 	"lmm/api/context/blog/domain/repository"
-	"lmm/api/context/blog/domain/service"
 	"lmm/api/http"
 	"log"
 )
@@ -28,8 +28,8 @@ func (ui *UI) PostBlog(c *http.Context) {
 	switch err {
 	case nil:
 		c.Header("Location", fmt.Sprintf("/blog/%d", blogID)).String(http.StatusCreated, "success")
-	case service.ErrEmptyBlogTitle:
-		c.String(http.StatusBadRequest, service.ErrEmptyBlogTitle.Error())
+	case domain.ErrEmptyBlogTitle:
+		c.String(http.StatusBadRequest, domain.ErrEmptyBlogTitle.Error())
 	default:
 		log.Println(err)
 		http.InternalServerError(c)
@@ -45,7 +45,7 @@ func (ui *UI) GetAllBlog(c *http.Context) {
 	switch err {
 	case nil:
 		c.JSON(http.StatusOK, blogPage)
-	case service.ErrInvalidCount, service.ErrInvalidPage:
+	case domain.ErrInvalidCount, domain.ErrInvalidPage:
 		c.String(http.StatusBadRequest, err.Error())
 	default:
 		log.Println(err)
@@ -58,8 +58,8 @@ func (ui *UI) GetBlog(c *http.Context) {
 	switch err {
 	case nil:
 		c.JSON(http.StatusOK, blog)
-	case service.ErrNoSuchBlog:
-		c.String(http.StatusNotFound, service.ErrNoSuchBlog.Error())
+	case domain.ErrNoSuchBlog:
+		c.String(http.StatusNotFound, domain.ErrNoSuchBlog.Error())
 	default:
 		log.Println(err)
 		http.InternalServerError(c)
@@ -77,14 +77,14 @@ func (ui *UI) UpdateBlog(c *http.Context) {
 	switch err {
 	case nil:
 		c.String(http.StatusOK, "success")
-	case service.ErrBlogNoChange:
+	case domain.ErrBlogNoChange:
 		http.NoContent(c)
-	case service.ErrEmptyBlogTitle:
-		c.String(http.StatusBadRequest, service.ErrEmptyBlogTitle.Error())
-	case service.ErrNoPermission:
-		c.String(http.StatusForbidden, service.ErrNoSuchBlog.Error())
-	case service.ErrNoSuchBlog:
-		c.String(http.StatusNotFound, service.ErrNoSuchBlog.Error())
+	case domain.ErrEmptyBlogTitle:
+		c.String(http.StatusBadRequest, domain.ErrEmptyBlogTitle.Error())
+	case domain.ErrNoPermission:
+		c.String(http.StatusForbidden, domain.ErrNoSuchBlog.Error())
+	case domain.ErrNoSuchBlog:
+		c.String(http.StatusNotFound, domain.ErrNoSuchBlog.Error())
 	default:
 		log.Println(err)
 		http.InternalServerError(c)
@@ -102,7 +102,7 @@ func (ui *UI) SetBlogCategory(c *http.Context) {
 	switch err {
 	case nil:
 		c.String(http.StatusOK, "success")
-	case service.ErrNoSuchBlog, service.ErrNoSuchCategory:
+	case domain.ErrNoSuchBlog, domain.ErrNoSuchCategory:
 		c.String(http.StatusBadRequest, err.Error())
 	default:
 		http.InternalServerError(c)
@@ -120,7 +120,7 @@ func (ui *UI) PostCategory(c *http.Context) {
 	switch err {
 	case nil:
 		c.Header("Location", fmt.Sprintf("/categories/%d", categoryID)).String(http.StatusCreated, "success")
-	case service.ErrInvalidCategoryName, service.ErrDuplicateCategoryName:
+	case domain.ErrInvalidCategoryName, domain.ErrDuplicateCategoryName:
 		c.String(http.StatusBadRequest, err.Error())
 	default:
 		log.Println(err)
@@ -139,12 +139,12 @@ func (ui *UI) UpdateCategory(c *http.Context) {
 	switch err {
 	case nil:
 		c.String(http.StatusOK, "success")
-	case service.ErrCategoryNoChanged:
+	case domain.ErrCategoryNoChanged:
 		http.NoContent(c)
-	case service.ErrInvalidCategoryName:
-		c.String(http.StatusBadRequest, service.ErrInvalidCategoryName.Error())
-	case service.ErrNoSuchCategory:
-		c.String(http.StatusNotFound, service.ErrNoSuchCategory.Error())
+	case domain.ErrInvalidCategoryName:
+		c.String(http.StatusBadRequest, domain.ErrInvalidCategoryName.Error())
+	case domain.ErrNoSuchCategory:
+		c.String(http.StatusNotFound, domain.ErrNoSuchCategory.Error())
 	default:
 		log.Println(err)
 		http.InternalServerError(c)
@@ -167,10 +167,10 @@ func (ui *UI) GetBlogCagetory(c *http.Context) {
 	switch err {
 	case nil:
 		c.JSON(http.StatusOK, category)
-	case service.ErrNoSuchBlog:
-		c.String(http.StatusNotFound, service.ErrNoSuchBlog.Error())
-	case service.ErrCategoryNotSet:
-		c.String(http.StatusNotFound, service.ErrCategoryNotSet.Error())
+	case domain.ErrNoSuchBlog:
+		c.String(http.StatusNotFound, domain.ErrNoSuchBlog.Error())
+	case domain.ErrCategoryNotSet:
+		c.String(http.StatusNotFound, domain.ErrCategoryNotSet.Error())
 	default:
 		http.InternalServerError(c)
 	}
@@ -181,8 +181,8 @@ func (ui *UI) DeleteCategory(c *http.Context) {
 	switch err {
 	case nil:
 		http.NoContent(c)
-	case service.ErrNoSuchCategory:
-		c.String(http.StatusNotFound, service.ErrNoSuchCategory.Error())
+	case domain.ErrNoSuchCategory:
+		c.String(http.StatusNotFound, domain.ErrNoSuchCategory.Error())
 	default:
 		log.Println(err)
 		http.InternalServerError(c)


### PR DESCRIPTION
原先在domain/service下定义错误变量的话，由于infra层也导入domain/service，在测试的时候就会造成循环导入(因为domain/service也导入infra)