### PR TITLE
set to strong consistency on test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
         name: datastore
         environment:
           PROJECT_ID: lmm-test
-        command: gcloud beta emulators datastore start --project=lmm-test --host-port=0.0.0.0:8081
+        command: gcloud beta emulators datastore start --project=lmm-test --host-port=0.0.0.0:8081 --consistency=1.0
     steps:
       - checkout
       - restore_cache:

--- a/api/docker-compose.test.yml
+++ b/api/docker-compose.test.yml
@@ -15,4 +15,4 @@ services:
     environment:
       PROJECT_ID: lmm-test
     command: |
-      gcloud beta emulators datastore start --project=lmm-test --host-port=0.0.0.0:8081
+      gcloud beta emulators datastore start --project=lmm-test --host-port=0.0.0.0:8081 --consistency=1.0


### PR DESCRIPTION
see gcloud beta emulators datastore start --help
--consistency=CONSISTENCY; default=0.9

Fraction of eventually consistent operations that should succeed immediately. Setting to 1.0 can be useful for unit tests, but may mask incorrect assumptions about non-ancestor queries which are eventually consistent.